### PR TITLE
Makefile: libsystemd-journal is no more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ MODULE_big   = pg_journal
 PG_CONFIG    = pg_config
 PKG_CONFIG   = pkg-config
 
-PG_CPPFLAGS = $(shell $(PKG_CONFIG) libsystemd-journal --cflags)
-SHLIB_LINK  = $(shell $(PKG_CONFIG) libsystemd-journal --libs)
+PG_CPPFLAGS = $(shell $(PKG_CONFIG) libsystemd --cflags)
+SHLIB_LINK  = $(shell $(PKG_CONFIG) libsystemd --libs)
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
libsystemd-journal was merged into libsystemd almost 4 years ago.
The code of pg_journal compiles, but is underlinked:
/usr/lib64/pgsql/pg_journal.so: undefined symbol: sd_journal_sendv